### PR TITLE
Added payofferram action.

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -194,6 +194,10 @@ CONTRACT atomicassets : public contract {
     ACTION declineoffer(
       uint64_t offer_id
     );
+    ACTION payofferram(
+      name payer,
+      uint64_t offer_id
+    );
 
     void receive_token_transfer(name from, name to, asset quantity, string memo);
     
@@ -407,7 +411,7 @@ void apply(uint64_t receiver, uint64_t code, uint64_t action)
       (createcol)(setcoldata)(addcolauth)(remcolauth)(addnotifyacc)(remnotifyacc) \
       (setmarketfee)(forbidnotify)(createscheme)(extendscheme)(createpreset) \
       (mintasset)(setassetdata)(announcedepo)(withdraw)(backasset)(burnasset) \
-      (createoffer)(canceloffer)(acceptoffer)(declineoffer) \
+      (createoffer)(canceloffer)(acceptoffer)(declineoffer)(payofferram) \
       (logtransfer)(lognewoffer)(lognewpreset)(logmint)(logsetdata)(logbackasset)(logburnasset))
 		}
 	} else if (action == name("transfer").value) {

--- a/resource/atomicassets.contracts.md
+++ b/resource/atomicassets.contracts.md
@@ -743,3 +743,24 @@ The recipient of the offer with the id {{offer_id}} declines the offer. The offe
 <div class="clauses">
 This action may only be called with the permission of the recipient of the offer.
 </div>
+
+
+
+<h1 class="contract">payofferram</h1>
+
+---
+spec_version: "0.2.0"
+title: Pays RAM for existing offer
+summary: '{{nowrap payer}} will pay for the RAM cost of the offer {{nowrap offer_id}}'
+icon: https://atomicassets.io/image/logo256.png#108AEE3530F4EB368A4B0C28800894CFBABF46534F48345BF6453090554C52D5
+---
+
+<b>Description:</b>
+<div class="description">
+{{payer}} pays for the RAM cost of the offer {{offer_id}}. The offer itself is not modified
+</div>
+
+<b>Clauses:</b>
+<div class="clauses">
+This action may only be called with the permission of {{payer}}.
+</div>

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -897,6 +897,11 @@ ACTION atomicassets::acceptoffer(
 }
 
 
+/**
+*  Declines an offer
+*  The offer is then erased from the tables
+*  @require_auth The offer's recipient
+*/
 ACTION atomicassets::declineoffer(
   uint64_t offer_id
 ) {
@@ -906,6 +911,27 @@ ACTION atomicassets::declineoffer(
   require_auth(offer_itr->offer_recipient);
 
   offers.erase(offer_itr);
+}
+
+
+/**
+* Pays for the RAM of an existing offer (thus freeing the RAM of the previous payer)
+* The main purpose for this is to allow dapps to pay for the RAM of offer that their users create
+* in order to make sure that the users don't run out of RAM
+* @require_auth payer
+*/
+ACTION atomicassets::payofferram(
+  name payer,
+  uint64_t offer_id
+) {
+  require_auth(payer);
+
+  auto offer_itr = offers.require_find(offer_id,
+  "No offer with this id exists");
+
+  offers.modify(offer_itr, payer, [&](auto& _offer) {
+
+  });
 }
 
 


### PR DESCRIPTION
With this action, anyone can pay for the RAM costs of an already existing offer. This can be useful for dapps that want to make sure that their users can trade without having to worry about RAM.