### PR TITLE
Abstracted the shared multi-index tables into a public header

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -1,3 +1,4 @@
+#include "atomicassets_public.hpp"
 #include <eosio/eosio.hpp>
 #include <eosio/singleton.hpp>
 #include <eosio/asset.hpp>
@@ -9,7 +10,7 @@ using namespace eosio;
 using namespace std;
 using namespace atomicdata;
 
-/*  
+/*
 Nofification Receipts for notify_accounts in a collection
 
 
@@ -70,14 +71,15 @@ Nofification Receipts for notify_accounts in a collection
     );
 
 */
+using namespace atomicassets_public;
 
 CONTRACT atomicassets : public contract {
-public:
+  public:
     using contract::contract;
 
     ACTION init();
 
-    ACTION admincoledit(vector <FORMAT> collection_format_extension);
+    ACTION admincoledit(vector<FORMAT> collection_format_extension);
 
     ACTION setversion(string new_version);
 
@@ -306,118 +308,31 @@ public:
     );
 
 
-private:
-
-    struct TOKEN {
-        name token_contract;
-        symbol token_symbol;
-    };
-
-    TABLE collections_s{
-        name                collection_name;
-        name                author;
-        bool                allow_notify;
-        vector<name>        authorized_accounts;
-        vector<name>        notify_accounts;
-        double              market_fee;
-        vector<uint8_t>     serialized_data;
-
-        uint64_t primary_key() const { return collection_name.value; };
-    };
-    typedef multi_index<name("collections"), collections_s> collections_t;
-
-
-    //Scope: collection_name
-    TABLE schemas_s{
-        name                schema_name;
-        vector<FORMAT>      format;
-
-        uint64_t primary_key() const { return schema_name.value; }
-    };
-    typedef multi_index<name("schemas"), schemas_s> schemas_t;
-
-
-    //Scope: collection_name
-    TABLE templates_s{
-        uint32_t            template_id;
-        name                schema_name;
-        bool                transferable;
-        bool                burnable;
-        uint32_t            max_supply;
-        uint32_t            issued_supply;
-        vector<uint8_t>     immutable_serialized_data;
-
-        uint64_t primary_key() const { return uint64_t{template_id}; }
-    };
-    typedef multi_index<name("templates"), templates_s> templates_t;
-
-
-    //Scope: owner
-    TABLE assets_s{
-        uint64_t            asset_id;
-        name                collection_name;
-        name                schema_name;
-        int32_t             template_id;
-        name                ram_payer;
-        vector<asset>       backed_tokens;
-        vector<uint8_t>     immutable_serialized_data;
-        vector<uint8_t>     mutable_serialized_data;
-
-        uint64_t primary_key() const { return asset_id; };
-    };
-    typedef multi_index<name("assets"), assets_s> assets_t;
-
-
-    TABLE offers_s{
-        uint64_t            offer_id;
-        name                sender;
-        name                recipient;
-        vector<uint64_t>    sender_asset_ids;
-        vector<uint64_t>    recipient_asset_ids;
-        string              memo;
-
-        uint64_t primary_key() const { return offer_id; };
-        uint64_t by_sender() const { return sender.value; };
-        uint64_t by_recipient() const { return recipient.value; };
-    };
-    typedef multi_index<name("offers"), offers_s,
-        indexed_by < name("sender"), const_mem_fun < offers_s, uint64_t, &offers_s::by_sender>>,
-    indexed_by<name("recipient"), const_mem_fun < offers_s, uint64_t, &offers_s::by_recipient>>>
-    offers_t;
-
-    TABLE balances_s{
-        name                owner;
-        vector<asset>       quantities;
-
-        uint64_t primary_key() const { return owner.value; };
-    };
-    typedef multi_index<name("balances"), balances_s> balances_t;
-
-
-    TABLE config_s{
-        uint64_t            asset_counter = 1099511627776; //2^40
-        int32_t             template_counter = 1;
-        uint64_t            offer_counter = 1;
-        vector<FORMAT>      collection_format = {};
-        vector<TOKEN>       supported_tokens = {};
+  private:
+    TABLE config_s {
+        uint64_t       asset_counter     = 1099511627776; // 2^40
+        int32_t        template_counter  = 1;
+        uint64_t       offer_counter     = 1;
+        vector<FORMAT> collection_format = {};
+        vector<TOKEN>  supported_tokens  = {};
     };
     typedef singleton<name("config"), config_s> config_t;
     // https://github.com/EOSIO/eosio.cdt/issues/280
     typedef multi_index<name("config"), config_s> config_t_for_abi;
 
-    TABLE tokenconfigs_s{
-        name                standard = name("atomicassets");
-        std::string         version = string("0.2.0");
+    TABLE tokenconfigs_s {
+        name        standard = name("atomicassets");
+        std::string version  = string("0.2.0");
     };
     typedef singleton<name("tokenconfigs"), tokenconfigs_s> tokenconfigs_t;
     // https://github.com/EOSIO/eosio.cdt/issues/280
     typedef multi_index<name("tokenconfigs"), tokenconfigs_s> tokenconfigs_t_for_abi;
 
 
-    collections_t collections = collections_t(get_self(), get_self().value);
-    offers_t offers = offers_t(get_self(), get_self().value);
-    balances_t balances = balances_t(get_self(), get_self().value);
-    config_t config = config_t(get_self(), get_self().value);
+    collections_t  collections  = collections_t(get_self(), get_self().value);
+    offers_t       offers       = offers_t(get_self(), get_self().value);
+    balances_t     balances     = balances_t(get_self(), get_self().value);
+    config_t       config       = config_t(get_self(), get_self().value);
     tokenconfigs_t tokenconfigs = tokenconfigs_t(get_self(), get_self().value);
 
 
@@ -460,19 +375,3 @@ private:
     templates_t get_templates(name collection_name);
 };
 
-extern "C"
-void apply(uint64_t receiver, uint64_t code, uint64_t action) {
-    if (code == receiver) {
-        switch (action) {
-            EOSIO_DISPATCH_HELPER(atomicassets, \
-            (init)(admincoledit)(setversion)(addconftoken)(transfer) \
-            (createcol)(setcoldata)(addcolauth)(remcolauth)(addnotifyacc)(remnotifyacc) \
-            (setmarketfee)(forbidnotify)(createschema)(extendschema)(createtempl)(locktemplate) \
-            (mintasset)(setassetdata)(announcedepo)(withdraw)(backasset)(burnasset) \
-            (createoffer)(canceloffer)(acceptoffer)(declineoffer)(payofferram) \
-            (logtransfer)(lognewoffer)(lognewtempl)(logmint)(logsetdata)(logbackasset)(logburnasset))
-        }
-    } else if (action == name("transfer").value) {
-        eosio::execute_action(name(receiver), name(code), &atomicassets::receive_token_transfer);
-    }
-}

--- a/include/atomicassets_public.hpp
+++ b/include/atomicassets_public.hpp
@@ -1,0 +1,89 @@
+#include <atomicdata.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/eosio.hpp>
+#include <eosio/singleton.hpp>
+
+using namespace atomicdata;
+
+namespace atomicassets_public {
+    struct TOKEN {
+        name   token_contract;
+        symbol token_symbol;
+    };
+
+    TABLE collections_s {
+        name            collection_name;
+        name            author;
+        bool            allow_notify;
+        vector<name>    authorized_accounts;
+        vector<name>    notify_accounts;
+        double          market_fee;
+        vector<uint8_t> serialized_data;
+
+        uint64_t primary_key() const { return collection_name.value; };
+    };
+    typedef multi_index<name("collections"), collections_s> collections_t;
+
+    // Scope: collection_name
+    TABLE schemas_s {
+        name           schema_name;
+        vector<FORMAT> format;
+
+        uint64_t primary_key() const { return schema_name.value; }
+    };
+    typedef multi_index<name("schemas"), schemas_s> schemas_t;
+
+    // Scope: collection_name
+    TABLE templates_s {
+        uint32_t        template_id;
+        name            schema_name;
+        bool            transferable;
+        bool            burnable;
+        uint32_t        max_supply;
+        uint32_t        issued_supply;
+        vector<uint8_t> immutable_serialized_data;
+
+        uint64_t primary_key() const { return uint64_t{template_id}; }
+    };
+    typedef multi_index<name("templates"), templates_s> templates_t;
+
+    // Scope: owner
+    TABLE assets_s {
+        uint64_t        asset_id;
+        name            collection_name;
+        name            schema_name;
+        int32_t         template_id;
+        name            ram_payer;
+        vector<asset>   backed_tokens;
+        vector<uint8_t> immutable_serialized_data;
+        vector<uint8_t> mutable_serialized_data;
+
+        uint64_t primary_key() const { return asset_id; };
+    };
+    typedef multi_index<name("assets"), assets_s> assets_t;
+
+    TABLE offers_s {
+        uint64_t         offer_id;
+        name             sender;
+        name             recipient;
+        vector<uint64_t> sender_asset_ids;
+        vector<uint64_t> recipient_asset_ids;
+        string           memo;
+
+        uint64_t primary_key() const { return offer_id; };
+        uint64_t by_sender() const { return sender.value; };
+        uint64_t by_recipient() const { return recipient.value; };
+    };
+    typedef multi_index<name("offers"), offers_s,
+        indexed_by<name("sender"), const_mem_fun<offers_s, uint64_t, &offers_s::by_sender>>,
+        indexed_by<name("recipient"), const_mem_fun<offers_s, uint64_t, &offers_s::by_recipient>>>
+        offers_t;
+
+    TABLE balances_s {
+        name          owner;
+        vector<asset> quantities;
+
+        uint64_t primary_key() const { return owner.value; };
+    };
+    typedef multi_index<name("balances"), balances_s> balances_t;
+} // namespace atomicassets_public

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -1,13 +1,14 @@
 #include <atomicassets.hpp>
 
-static constexpr symbol WAX_SYMBOL = symbol("WAX", 8);
+static constexpr symbol WAX_SYMBOL     = symbol("WAX", 8);
 static constexpr double MAX_MARKET_FEE = 0.15;
 
+using namespace atomicassets_public;
 
 /**
-*  Initializes the config table. Only needs to be called once when first deploying the contract
-*  @required_auth The contract itself
-*/
+ *  Initializes the config table. Only needs to be called once when first deploying the contract
+ *  @required_auth The contract itself
+ */
 ACTION atomicassets::init() {
     require_auth(get_self());
     config.get_or_create(get_self(), config_s{});
@@ -15,10 +16,10 @@ ACTION atomicassets::init() {
 }
 
 /**
-*  Adds one or more lines to the format that is used for collection data serialization
-*  @required_auth The contract itself
-*/
-ACTION atomicassets::admincoledit(vector <atomicdata::FORMAT> collection_format_extension) {
+ *  Adds one or more lines to the format that is used for collection data serialization
+ *  @required_auth The contract itself
+ */
+ACTION atomicassets::admincoledit(vector<atomicdata::FORMAT> collection_format_extension) {
     require_auth(get_self());
 
     check(collection_format_extension.size() != 0, "Need to add at least one new line");
@@ -36,23 +37,23 @@ ACTION atomicassets::admincoledit(vector <atomicdata::FORMAT> collection_format_
 
 
 /**
-*  Sets the version for the tokenconfigs table
-*  @required_auth The contract itself
-*/
+ *  Sets the version for the tokenconfigs table
+ *  @required_auth The contract itself
+ */
 ACTION atomicassets::setversion(string new_version) {
     require_auth(get_self());
 
     tokenconfigs_s current_tokenconfigs = tokenconfigs.get();
-    current_tokenconfigs.version = new_version;
+    current_tokenconfigs.version        = new_version;
 
     tokenconfigs.set(current_tokenconfigs, get_self());
 }
 
 
 /**
-*  Adds a token that can then be backed to assets
-*  @required_auth The contract itself
-*/
+ *  Adds a token that can then be backed to assets
+ *  @required_auth The contract itself
+ */
 ACTION atomicassets::addconftoken(name token_contract, symbol token_symbol) {
     require_auth(get_self());
 
@@ -72,9 +73,9 @@ ACTION atomicassets::addconftoken(name token_contract, symbol token_symbol) {
 
 
 /**
-*  Transfers one or more assets to another account
-*  @required_auth The from account
-*/
+ *  Transfers one or more assets to another account
+ *  @required_auth The from account
+ */
 ACTION atomicassets::transfer(
     name from,
     name to,
@@ -89,8 +90,8 @@ ACTION atomicassets::transfer(
 
 
 /**
-*  Creates a new collection
-*/
+ *  Creates a new collection
+ */
 ACTION atomicassets::createcol(
     name author,
     name collection_name,
@@ -129,22 +130,22 @@ ACTION atomicassets::createcol(
     config_s current_config = config.get();
 
     collections.emplace(author, [&](auto &_collection) {
-        _collection.collection_name = collection_name;
-        _collection.author = author;
-        _collection.allow_notify = allow_notify;
+        _collection.collection_name     = collection_name;
+        _collection.author              = author;
+        _collection.allow_notify        = allow_notify;
         _collection.authorized_accounts = authorized_accounts;
-        _collection.notify_accounts = notify_accounts;
-        _collection.market_fee = market_fee;
-        _collection.serialized_data = serialize(data, current_config.collection_format);
+        _collection.notify_accounts     = notify_accounts;
+        _collection.market_fee          = market_fee;
+        _collection.serialized_data     = serialize(data, current_config.collection_format);
     });
 }
 
 
 /**
-*  Sets the collection data, which is then serialized with the collection format set in the config
-*  This data is used by 3rd party apps and sites to display additional information about the collection
-*  @required_auth The collection author
-*/
+ *  Sets the collection data, which is then serialized with the collection format set in the config
+ *  This data is used by 3rd party apps and sites to display additional information about the collection
+ *  @required_auth The collection author
+ */
 ACTION atomicassets::setcoldata(
     name collection_name,
     ATTRIBUTE_MAP data
@@ -164,10 +165,10 @@ ACTION atomicassets::setcoldata(
 
 
 /**
-*  Adds an account to the authorized_accounts list of a collection
-*  This will allow the account to create and edit both templates and assets that belong to this collection
-*  @required_atuh The collection author
-*/
+ *  Adds an account to the authorized_accounts list of a collection
+ *  This will allow the account to create and edit both templates and assets that belong to this collection
+ *  @required_atuh The collection author
+ */
 ACTION atomicassets::addcolauth(
     name collection_name,
     name account_to_add
@@ -179,7 +180,7 @@ ACTION atomicassets::addcolauth(
 
     check(is_account(account_to_add), "The account does not exist");
 
-    vector <name> authorized_accounts = collection_itr->authorized_accounts;
+    vector<name> authorized_accounts = collection_itr->authorized_accounts;
     check(std::find(authorized_accounts.begin(), authorized_accounts.end(), account_to_add) ==
           authorized_accounts.end(),
         "The account is already an authorized account");
@@ -193,9 +194,9 @@ ACTION atomicassets::addcolauth(
 
 
 /**
-*  Removes an account from the authorized_accounts list of a collection
-*  @required_auth The collection author
-*/
+ *  Removes an account from the authorized_accounts list of a collection
+ *  @required_auth The collection author
+ */
 ACTION atomicassets::remcolauth(
     name collection_name,
     name account_to_remove
@@ -204,7 +205,7 @@ ACTION atomicassets::remcolauth(
         "No collection with this name exists");
 
     require_auth(collection_itr->author);
-    vector <name> authorized_accounts = collection_itr->authorized_accounts;
+    vector<name> authorized_accounts = collection_itr->authorized_accounts;
 
     auto account_itr = std::find(authorized_accounts.begin(), authorized_accounts.end(), account_to_remove);
 
@@ -219,12 +220,12 @@ ACTION atomicassets::remcolauth(
 
 
 /**
-*  Adds an account to the notify_accounts list of a collection
+ *  Adds an account to the notify_accounts list of a collection
 *  This will make the account get notified on every relevant action concerning this collection using require_recipient()
 *  NOTE: It will consequently allow the account to make any of these actions throw (fail).
 *        Only add trusted accounts to this list
-*  @required_atuh The collection author
-*/
+ *  @required_atuh The collection author
+ */
 ACTION atomicassets::addnotifyacc(
     name collection_name,
     name account_to_add
@@ -238,7 +239,7 @@ ACTION atomicassets::addnotifyacc(
 
     check(is_account(account_to_add), "The account does not exist");
 
-    vector <name> notify_accounts = collection_itr->notify_accounts;
+    vector<name> notify_accounts = collection_itr->notify_accounts;
 
     check(std::find(notify_accounts.begin(), notify_accounts.end(), account_to_add) == notify_accounts.end(),
         "The account is already a notify account");
@@ -252,9 +253,9 @@ ACTION atomicassets::addnotifyacc(
 
 
 /**
-*  Removes an account from the notify_accounts list of a collection
-*  @required_auth The collection author
-*/
+ *  Removes an account from the notify_accounts list of a collection
+ *  @required_auth The collection author
+ */
 ACTION atomicassets::remnotifyacc(
     name collection_name,
     name account_to_remove
@@ -263,7 +264,7 @@ ACTION atomicassets::remnotifyacc(
         "No collection with this name exists");
 
     require_auth(collection_itr->author);
-    vector <name> notify_accounts = collection_itr->notify_accounts;
+    vector<name> notify_accounts = collection_itr->notify_accounts;
 
     auto account_itr = std::find(notify_accounts.begin(), notify_accounts.end(), account_to_remove);
 
@@ -278,9 +279,9 @@ ACTION atomicassets::remnotifyacc(
 
 
 /**
-* Sets (changes) the market fee for an existing collection
-* @required_auth The collection author
-*/
+ * Sets (changes) the market fee for an existing collection
+ * @required_auth The collection author
+ */
 ACTION atomicassets::setmarketfee(
     name collection_name,
     double market_fee
@@ -300,10 +301,10 @@ ACTION atomicassets::setmarketfee(
 
 
 /**
-* Sets allow_notify to false for a collection where it has previously been true
-* The collection's notify_accounts list must be empty
-* @required_auth The collection author
-*/
+ * Sets allow_notify to false for a collection where it has previously been true
+ * The collection's notify_accounts list must be empty
+ * @required_auth The collection author
+ */
 ACTION atomicassets::forbidnotify(
     name collection_name
 ) {
@@ -323,11 +324,11 @@ ACTION atomicassets::forbidnotify(
 
 
 /**
-*  Creates a new schema
-*  schemas can only be extended in the future, but never changed retroactively.
-*  This guarantees a correct deserialization for existing templates and assets.
-*  @required_auth authorized_creator, who is within the authorized_accounts list of the collection
-*/
+ *  Creates a new schema
+ *  schemas can only be extended in the future, but never changed retroactively.
+ *  This guarantees a correct deserialization for existing templates and assets.
+ *  @required_auth authorized_creator, who is within the authorized_accounts list of the collection
+ */
 ACTION atomicassets::createschema(
     name authorized_creator,
     name collection_name,
@@ -354,15 +355,15 @@ ACTION atomicassets::createschema(
 
     collection_schemas.emplace(authorized_creator, [&](auto &_schema) {
         _schema.schema_name = schema_name;
-        _schema.format = schema_format;
+        _schema.format      = schema_format;
     });
 }
 
 
 /**
-*  Adds one or more lines to the format of an existing schema
-*  @required_auth authorized_editor, who is within the authorized_accounts list of the collection
-*/
+ *  Adds one or more lines to the format of an existing schema
+ *  @required_auth authorized_editor, who is within the authorized_accounts list of the collection
+ */
 ACTION atomicassets::extendschema(
     name authorized_editor,
     name collection_name,
@@ -373,7 +374,7 @@ ACTION atomicassets::extendschema(
 
     auto collection_itr = collections.require_find(collection_name.value,
         "No collection with this name exists");
-    
+
     check_has_collection_auth(
         authorized_editor,
         collection_name,
@@ -386,7 +387,7 @@ ACTION atomicassets::extendschema(
     auto schema_itr = collection_schemas.require_find(schema_name.value,
         "No schema with this name exists for this collection");
 
-    vector <FORMAT> lines = schema_itr->format;
+    vector<FORMAT> lines = schema_itr->format;
     lines.insert(lines.end(), schema_format_extension.begin(), schema_format_extension.end());
     check_format(lines);
 
@@ -397,9 +398,9 @@ ACTION atomicassets::extendschema(
 
 
 /**
-*  Creates a new template
-*  @required_auth authorized_creator, who is within the authorized_accounts list of the collection
-*/
+ *  Creates a new template
+ *  @required_auth authorized_creator, who is within the authorized_accounts list of the collection
+ */
 ACTION atomicassets::createtempl(
     name authorized_creator,
     name collection_name,
@@ -413,7 +414,7 @@ ACTION atomicassets::createtempl(
 
     auto collection_itr = collections.require_find(collection_name.value,
         "No collection with this name exists");
-    
+
     check_has_collection_auth(
         authorized_creator,
         collection_name,
@@ -425,18 +426,18 @@ ACTION atomicassets::createtempl(
         "No schema with this name exists");
 
     config_s current_config = config.get();
-    uint32_t template_id = current_config.template_counter++;
+    uint32_t template_id    = current_config.template_counter++;
     config.set(current_config, get_self());
 
     templates_t collection_templates = get_templates(collection_name);
 
     collection_templates.emplace(authorized_creator, [&](auto &_template) {
-        _template.template_id = template_id;
-        _template.schema_name = schema_name;
-        _template.transferable = transferable;
-        _template.burnable = burnable;
-        _template.max_supply = max_supply;
-        _template.issued_supply = 0;
+        _template.template_id               = template_id;
+        _template.schema_name               = schema_name;
+        _template.transferable              = transferable;
+        _template.burnable                  = burnable;
+        _template.max_supply                = max_supply;
+        _template.issued_supply             = 0;
         _template.immutable_serialized_data = serialize(immutable_data, schema_itr->format);
     });
 
@@ -459,10 +460,10 @@ ACTION atomicassets::createtempl(
 
 
 /**
-* Sets the max supply of the template to the issued supply
-* This means that afterwards no new assets of this template can be minted
-* @required_auth authorized_editor, who is within the authorized_accounts list of the collection
-**/
+ * Sets the max supply of the template to the issued supply
+ * This means that afterwards no new assets of this template can be minted
+ * @required_auth authorized_editor, who is within the authorized_accounts list of the collection
+ **/
 ACTION atomicassets::locktemplate(
     name authorized_editor,
     name collection_name,
@@ -472,21 +473,21 @@ ACTION atomicassets::locktemplate(
 
     auto collection_itr = collections.require_find(collection_name.value,
         "No collection with this name exists");
-    
+
     check_has_collection_auth(
         authorized_editor,
         collection_name,
         "The editor is not authorized within the collection"
     );
-    
+
     templates_t collection_templates = get_templates(collection_name);
     auto template_itr = collection_templates.require_find(template_id,
         "No template with the specified id exists for the specified colleciton");
-    
+
     check(template_itr->issued_supply != 0,
         "Can't lock a template that does not have at least one issued asset");
-    
-    collection_templates.modify(template_itr, same_payer, [&](auto& _template) {
+
+    collection_templates.modify(template_itr, same_payer, [&](auto &_template) {
         _template.max_supply = _template.issued_supply;
     });
 }
@@ -548,19 +549,19 @@ ACTION atomicassets::mintasset(
     check_name_length(mutable_data);
 
     config_s current_config = config.get();
-    uint64_t asset_id = current_config.asset_counter++;
+    uint64_t asset_id       = current_config.asset_counter++;
     config.set(current_config, get_self());
 
     assets_t new_owner_assets = get_assets(new_asset_owner);
     new_owner_assets.emplace(authorized_minter, [&](auto &_asset) {
-        _asset.asset_id = asset_id;
-        _asset.collection_name = collection_name;
-        _asset.schema_name = schema_name;
-        _asset.template_id = template_id;
-        _asset.ram_payer = authorized_minter;
-        _asset.backed_tokens = {};
+        _asset.asset_id                  = asset_id;
+        _asset.collection_name           = collection_name;
+        _asset.schema_name               = schema_name;
+        _asset.template_id               = template_id;
+        _asset.ram_payer                 = authorized_minter;
+        _asset.backed_tokens             = {};
         _asset.immutable_serialized_data = serialize(immutable_data, schema_itr->format);
-        _asset.mutable_serialized_data = serialize(mutable_data, schema_itr->format);
+        _asset.mutable_serialized_data   = serialize(mutable_data, schema_itr->format);
     });
 
 
@@ -581,8 +582,8 @@ ACTION atomicassets::mintasset(
         )
     ).send();
 
-    //Calls the internal_back_asset function with handles asset backing.
-    //It will throw if authorized_minter does not have a sufficient balance to pay for the backed tokens
+    // Calls the internal_back_asset function with handles asset backing.
+    // It will throw if authorized_minter does not have a sufficient balance to pay for the backed tokens
     for (asset &token : tokens_to_back) {
         internal_back_asset(authorized_minter, new_asset_owner, asset_id, token);
     }
@@ -618,7 +619,7 @@ ACTION atomicassets::setassetdata(
     check_name_length(new_mutable_data);
 
     schemas_t collection_schemas = get_schemas(asset_itr->collection_name);
-    auto schema_itr = collection_schemas.find(asset_itr->schema_name.value);
+    auto      schema_itr         = collection_schemas.find(asset_itr->schema_name.value);
 
     ATTRIBUTE_MAP deserialized_old_data = deserialize(
         asset_itr->mutable_serialized_data,
@@ -634,23 +635,23 @@ ACTION atomicassets::setassetdata(
 
 
     owner_assets.modify(asset_itr, authorized_editor, [&](auto &_asset) {
-        _asset.ram_payer = authorized_editor;
+        _asset.ram_payer               = authorized_editor;
         _asset.mutable_serialized_data = serialize(new_mutable_data, schema_itr->format);
     });
 }
 
 
 /**
-* This action is used to add a zero value asset to the quantities vector of owner in the balances table
-* If no row exists for owner, a new one is created
-* This action needs to be called before transferring (depositing) any tokens to the AtomicAssets smart contract,
-* in order to pay for the RAM that otherwise would have to be paid by the AtomicAssets smart contract
-*
-* To pass a symbol to eosio as a string, use the following format: <precision>,<symbol_code>
-* So for example: "8,WAX"
-*
-* @required_auth owner
-*/
+ * This action is used to add a zero value asset to the quantities vector of owner in the balances table
+ * If no row exists for owner, a new one is created
+ * This action needs to be called before transferring (depositing) any tokens to the AtomicAssets smart contract,
+ * in order to pay for the RAM that otherwise would have to be paid by the AtomicAssets smart contract
+ *
+ * To pass a symbol to eosio as a string, use the following format: <precision>,<symbol_code>
+ * So for example: "8,WAX"
+ *
+ * @required_auth owner
+ */
 ACTION atomicassets::announcedepo(
     name owner,
     symbol symbol_to_announce
@@ -671,14 +672,14 @@ ACTION atomicassets::announcedepo(
     auto balance_itr = balances.find(owner.value);
 
     if (balance_itr == balances.end()) {
-        vector <asset> quantities = {asset(0, symbol_to_announce)};
+        vector<asset> quantities = {asset(0, symbol_to_announce)};
         balances.emplace(owner, [&](auto &_balance) {
-            _balance.owner = owner;
+            _balance.owner      = owner;
             _balance.quantities = quantities;
         });
 
     } else {
-        vector <asset> quantities = balance_itr->quantities;
+        vector<asset> quantities = balance_itr->quantities;
         for (asset &token : quantities) {
             check(token.symbol != symbol_to_announce,
                 "The specified symbol has already been announced");
@@ -693,10 +694,10 @@ ACTION atomicassets::announcedepo(
 
 
 /**
-* Withdraws fungible tokens that were previously deposited
-*
-* @required_auth owner
-*/
+ * Withdraws fungible tokens that were previously deposited
+ *
+ * @required_auth owner
+ */
 ACTION atomicassets::withdraw(
     name owner,
     asset token_to_withdraw
@@ -705,7 +706,7 @@ ACTION atomicassets::withdraw(
 
     check(token_to_withdraw.amount > 0, "token_to_withdraw must be positive");
 
-    //The internal_decrease_balance function will throw if owner does not have a sufficient balance
+    // The internal_decrease_balance function will throw if owner does not have a sufficient balance
     internal_decrease_balance(owner, token_to_withdraw);
 
     config_s current_config = config.get();
@@ -730,11 +731,11 @@ ACTION atomicassets::withdraw(
 
 
 /**
-* Backs an asset with a fungible token that was previously deposited by payer
-* payer also pays for the full RAM of the asset that is backed
-* 
-* @required_auth payer
-*/
+ * Backs an asset with a fungible token that was previously deposited by payer
+ * payer also pays for the full RAM of the asset that is backed
+ *
+ * @required_auth payer
+ */
 ACTION atomicassets::backasset(
     name payer,
     name asset_owner,
@@ -748,11 +749,11 @@ ACTION atomicassets::backasset(
 
 
 /**
-*  Burns (deletes) an asset
-*  Only works if the "burnable" bool in the related template is true
-*  If the asset has been backed with tokens previously, they are sent to the owner of the asset
-*  @required_auth asset_owner
-*/
+ *  Burns (deletes) an asset
+ *  Only works if the "burnable" bool in the related template is true
+ *  If the asset has been backed with tokens previously, they are sent to the owner of the asset
+ *  @required_auth asset_owner
+ */
 ACTION atomicassets::burnasset(
     name asset_owner,
     uint64_t asset_id
@@ -792,7 +793,7 @@ ACTION atomicassets::burnasset(
     }
 
     schemas_t collection_schemas = get_schemas(asset_itr->collection_name);
-    auto schema_itr = collection_schemas.find(asset_itr->schema_name.value);
+    auto      schema_itr         = collection_schemas.find(asset_itr->schema_name.value);
 
     ATTRIBUTE_MAP deserialized_immutable_data = deserialize(
         asset_itr->immutable_serialized_data,
@@ -825,10 +826,10 @@ ACTION atomicassets::burnasset(
 
 
 /**
-*  Creates an offer
-*  Offers are two sided, with the only requirement being that at least one asset is included in one of the sides
-*  @required_auth sender
-*/
+ *  Creates an offer
+ *  Offers are two sided, with the only requirement being that at least one asset is included in one of the sides
+ *  @required_auth sender
+ */
 ACTION atomicassets::createoffer(
     name sender,
     name recipient,
@@ -845,7 +846,7 @@ ACTION atomicassets::createoffer(
 
     check(memo.length() <= 256, "An offer memo can only be 256 characters max");
 
-    assets_t sender_assets = get_assets(sender);
+    assets_t sender_assets    = get_assets(sender);
     assets_t recipient_assets = get_assets(recipient);
 
     for (uint64_t asset_id : sender_asset_ids) {
@@ -874,14 +875,14 @@ ACTION atomicassets::createoffer(
     }
 
     config_s current_config = config.get();
-    uint64_t offer_id = current_config.offer_counter++;
+    uint64_t offer_id       = current_config.offer_counter++;
     offers.emplace(sender, [&](auto &_offer) {
-        _offer.offer_id = offer_id;
-        _offer.sender = sender;
-        _offer.recipient = recipient;
-        _offer.sender_asset_ids = sender_asset_ids;
+        _offer.offer_id            = offer_id;
+        _offer.sender              = sender;
+        _offer.recipient           = recipient;
+        _offer.sender_asset_ids    = sender_asset_ids;
         _offer.recipient_asset_ids = recipient_asset_ids;
-        _offer.memo = memo;
+        _offer.memo                = memo;
     });
 
     config.set(current_config, get_self());
@@ -896,9 +897,9 @@ ACTION atomicassets::createoffer(
 
 
 /**
-*  Cancels (deletes) an existing offer
-*  @required_auth The offer's creator
-*/
+ *  Cancels (deletes) an existing offer
+ *  @required_auth The offer's creator
+ */
 ACTION atomicassets::canceloffer(
     uint64_t offer_id
 ) {
@@ -912,11 +913,11 @@ ACTION atomicassets::canceloffer(
 
 
 /**
-*  Accepts an offer
-*  The items specified in the offer from either side are transferred to the corresponding other side
-*  If a new scope needs to be created, each side of the offer will pay for their own scope
-*  @require_auth The offer's recipient
-*/
+ *  Accepts an offer
+ *  The items specified in the offer from either side are transferred to the corresponding other side
+ *  If a new scope needs to be created, each side of the offer will pay for their own scope
+ *  @require_auth The offer's recipient
+ */
 ACTION atomicassets::acceptoffer(
     uint64_t offer_id
 ) {
@@ -928,7 +929,7 @@ ACTION atomicassets::acceptoffer(
     require_recipient(offer_itr->sender);
     require_recipient(offer_itr->recipient);
 
-    assets_t sender_assets = get_assets(offer_itr->sender);
+    assets_t sender_assets    = get_assets(offer_itr->sender);
     assets_t recipient_assets = get_assets(offer_itr->recipient);
     for (uint64_t asset_id : offer_itr->sender_asset_ids) {
         sender_assets.require_find(asset_id,
@@ -942,7 +943,7 @@ ACTION atomicassets::acceptoffer(
     }
 
     if (offer_itr->recipient_asset_ids.size() != 0) {
-        //Potential scope costs for offer sender are offset by removing the entry from the offer table
+        // Potential scope costs for offer sender are offset by removing the entry from the offer table
         internal_transfer(
             offer_itr->recipient,
             offer_itr->sender,
@@ -967,10 +968,10 @@ ACTION atomicassets::acceptoffer(
 
 
 /**
-*  Declines an offer
-*  The offer is then erased from the tables
-*  @require_auth The offer's recipient
-*/
+ *  Declines an offer
+ *  The offer is then erased from the tables
+ *  @require_auth The offer's recipient
+ */
 ACTION atomicassets::declineoffer(
     uint64_t offer_id
 ) {
@@ -984,11 +985,11 @@ ACTION atomicassets::declineoffer(
 
 
 /**
-* Pays for the RAM of an existing offer (thus freeing the RAM of the previous payer)
-* The main purpose for this is to allow dapps to pay for the RAM of offer that their users create
-* in order to make sure that the users don't run out of RAM
-* @require_auth payer
-*/
+ * Pays for the RAM of an existing offer (thus freeing the RAM of the previous payer)
+ * The main purpose for this is to allow dapps to pay for the RAM of offer that their users create
+ * in order to make sure that the users don't run out of RAM
+ * @require_auth payer
+ */
 ACTION atomicassets::payofferram(
     name payer,
     uint64_t offer_id
@@ -1005,9 +1006,9 @@ ACTION atomicassets::payofferram(
 
 
 /**
-*  This function is called when a transfer receipt from any token contract is sent to the atomicassets contract
-*  It handels deposits and adds the transferred tokens to the sender's balance table row
-*/
+ *  This function is called when a transfer receipt from any token contract is sent to the atomicassets contract
+ *  It handels deposits and adds the transferred tokens to the sender's balance table row
+ */
 void atomicassets::receive_token_transfer(name from, name to, asset quantity, string memo) {
     if (to != _self) {
         return;
@@ -1028,8 +1029,8 @@ void atomicassets::receive_token_transfer(name from, name to, asset quantity, st
             "You need to first initialize the balance table row using the announcedepo action");
 
         //Quantities refers to the quantities value in the balances table row, quantity is the asset that was transferred
-        vector <asset> quantities = balance_itr->quantities;
-        bool found_token = false;
+        vector<asset> quantities  = balance_itr->quantities;
+        bool          found_token = false;
         for (asset &token : quantities) {
             if (token.symbol == quantity.symbol) {
                 found_token = true;
@@ -1120,8 +1121,8 @@ ACTION atomicassets::logsetdata(
 ) {
     require_auth(get_self());
 
-    assets_t owner_assets = get_assets(asset_owner);
-    auto asset_itr = owner_assets.find(asset_id);
+    assets_t owner_assets   = get_assets(asset_owner);
+    auto     asset_itr      = owner_assets.find(asset_id);
 
     notify_collection_accounts(asset_itr->collection_name);
 }
@@ -1136,8 +1137,8 @@ ACTION atomicassets::logbackasset(
 
     require_recipient(asset_owner);
 
-    assets_t owner_assets = get_assets(asset_owner);
-    auto asset_itr = owner_assets.find(asset_id);
+    assets_t owner_assets   = get_assets(asset_owner);
+    auto     asset_itr      = owner_assets.find(asset_id);
 
     notify_collection_accounts(asset_itr->collection_name);
 }
@@ -1161,13 +1162,13 @@ ACTION atomicassets::logburnasset(
 
 
 /**
-*  Transfers need to be handled like this (as a function instead of an action), because when accepting an offer,
-*  we want each side of the offer to pay for their own scope. Because the recipient authorized the accept action,
-*  he can be charged the RAM for his own scope, and because the offer is removed from the table, which was previously
-*  paid by the offer sender, the action RAM delta for the sender account will still be positive even after paying
-*  for the scope. This is allowed by the protocol feature RAM_RESTRICTIONS which needs to be enabled on the blockchain
-*  that this contract is deployed on.
-*/
+ *  Transfers need to be handled like this (as a function instead of an action), because when accepting an offer,
+ *  we want each side of the offer to pay for their own scope. Because the recipient authorized the accept action,
+ *  he can be charged the RAM for his own scope, and because the offer is removed from the table, which was previously
+ *  paid by the offer sender, the action RAM delta for the sender account will still be positive even after paying
+ *  for the scope. This is allowed by the protocol feature RAM_RESTRICTIONS which needs to be enabled on the blockchain
+ *  that this contract is deployed on.
+ */
 void atomicassets::internal_transfer(
     name from,
     name to,
@@ -1184,16 +1185,16 @@ void atomicassets::internal_transfer(
     check(memo.length() <= 256, "A transfer memo can only be 256 characters max");
 
     assets_t from_assets = get_assets(from);
-    assets_t to_assets = get_assets(to);
+    assets_t to_assets   = get_assets(to);
 
-    map <name, vector<uint64_t>> collection_to_assets_transferred = {};
+    map<name, vector<uint64_t>> collection_to_assets_transferred = {};
 
     for (uint64_t asset_id : asset_ids) {
         auto asset_itr = from_assets.require_find(asset_id,
             ("Sender doesn't own at least one of the provided assets (ID: " +
              to_string(asset_id) + ")").c_str());
 
-        //Existence doesn't have to be checked because this always has to exist
+        // Existence doesn't have to be checked because this always has to exist
         if (asset_itr->template_id >= 0) {
             templates_t collection_templates = get_templates(asset_itr->collection_name);
 
@@ -1202,7 +1203,7 @@ void atomicassets::internal_transfer(
                 ("At least one asset isn't transferable (ID: " + to_string(asset_id) + ")").c_str());
         }
 
-        //This is needed for sending noficiations later
+        // This is needed for sending noficiations later
         if (collection_to_assets_transferred.find(asset_itr->collection_name) !=
             collection_to_assets_transferred.end()) {
             collection_to_assets_transferred[asset_itr->collection_name].push_back(asset_id);
@@ -1210,33 +1211,33 @@ void atomicassets::internal_transfer(
             collection_to_assets_transferred[asset_itr->collection_name] = {asset_id};
         }
 
-        //to assets are empty => no scope has been created yet
+        // to assets are empty => no scope has been created yet
         bool no_previous_scope = to_assets.begin() == to_assets.end();
         if (no_previous_scope) {
-            //A dummy asset is emplaced, which makes the scope_payer pay for the ram of the scope
-            //This asset is later deleted again.
-            //This action will therefore fail is the scope_payer didn't authorize the action
+            // A dummy asset is emplaced, which makes the scope_payer pay for the ram of the scope
+            // This asset is later deleted again.
+            // This action will therefore fail is the scope_payer didn't authorize the action
             to_assets.emplace(scope_payer, [&](auto &_asset) {
-                _asset.asset_id = ULLONG_MAX;
-                _asset.collection_name = name("");
-                _asset.schema_name = name("");
-                _asset.template_id = -1;
-                _asset.ram_payer = scope_payer;
-                _asset.backed_tokens = {};
+                _asset.asset_id                  = ULLONG_MAX;
+                _asset.collection_name           = name("");
+                _asset.schema_name               = name("");
+                _asset.template_id               = -1;
+                _asset.ram_payer                 = scope_payer;
+                _asset.backed_tokens             = {};
                 _asset.immutable_serialized_data = {};
-                _asset.mutable_serialized_data = {};
+                _asset.mutable_serialized_data   = {};
             });
         }
 
         to_assets.emplace(asset_itr->ram_payer, [&](auto &_asset) {
-            _asset.asset_id = asset_itr->asset_id;
-            _asset.collection_name = asset_itr->collection_name;
-            _asset.schema_name = asset_itr->schema_name;
-            _asset.template_id = asset_itr->template_id;
-            _asset.ram_payer = asset_itr->ram_payer;
-            _asset.backed_tokens = asset_itr->backed_tokens;
+            _asset.asset_id                  = asset_itr->asset_id;
+            _asset.collection_name           = asset_itr->collection_name;
+            _asset.schema_name               = asset_itr->schema_name;
+            _asset.template_id               = asset_itr->template_id;
+            _asset.ram_payer                 = asset_itr->ram_payer;
+            _asset.backed_tokens             = asset_itr->backed_tokens;
             _asset.immutable_serialized_data = asset_itr->immutable_serialized_data;
-            _asset.mutable_serialized_data = asset_itr->mutable_serialized_data;
+            _asset.mutable_serialized_data   = asset_itr->mutable_serialized_data;
         });
 
         from_assets.erase(asset_itr);
@@ -1246,8 +1247,8 @@ void atomicassets::internal_transfer(
         }
     }
 
-    //Sending notifications
-    for (const auto&[collection, assets_transferred] : collection_to_assets_transferred) {
+    // Sending notifications
+    for (const auto &[collection, assets_transferred] : collection_to_assets_transferred) {
         action(
             permission_level{get_self(), name("active")},
             get_self(),
@@ -1259,9 +1260,9 @@ void atomicassets::internal_transfer(
 
 
 /**
-*  The specified asset is backed by the specified quantitiy.
-*  This is done in an internal function because it is needed both in the mintasset and the backasset action
-*/
+ *  The specified asset is backed by the specified quantitiy.
+ *  This is done in an internal function because it is needed both in the mintasset and the backasset action
+ */
 void atomicassets::internal_back_asset(
     name payer,
     name asset_owner,
@@ -1270,7 +1271,7 @@ void atomicassets::internal_back_asset(
 ) {
     check(token_to_back.amount > 0, "token_to_back must be positive");
 
-    //The internal_decrease_balance function will throw if payer does not have a sufficient balance
+    // The internal_decrease_balance function will throw if payer does not have a sufficient balance
     internal_decrease_balance(payer, token_to_back);
 
     assets_t owner_assets = get_assets(asset_owner);
@@ -1284,8 +1285,8 @@ void atomicassets::internal_back_asset(
         check(template_itr->burnable, "The asset is not burnable. Only burnable assets can be backed.");
     }
 
-    vector <asset> backed_tokens = asset_itr->backed_tokens;
-    bool found_backed_token = false;
+    vector<asset> backed_tokens      = asset_itr->backed_tokens;
+    bool          found_backed_token = false;
     for (asset &token : backed_tokens) {
         if (token.symbol == token_to_back.symbol) {
             found_backed_token = true;
@@ -1298,7 +1299,7 @@ void atomicassets::internal_back_asset(
     }
 
     owner_assets.modify(asset_itr, payer, [&](auto &_asset) {
-        _asset.ram_payer = payer;
+        _asset.ram_payer     = payer;
         _asset.backed_tokens = backed_tokens;
     });
 
@@ -1312,10 +1313,10 @@ void atomicassets::internal_back_asset(
 
 
 /**
-*  Decreases the balance of a specified account by a specified quantity
-*  If the specified account does not have at least as much tokens in the balance as should be removed
-*  the transaction will fail
-*/
+ *  Decreases the balance of a specified account by a specified quantity
+ *  If the specified account does not have at least as much tokens in the balance as should be removed
+ *  the transaction will fail
+ */
 void atomicassets::internal_decrease_balance(
     name owner,
     asset quantity
@@ -1323,8 +1324,8 @@ void atomicassets::internal_decrease_balance(
     auto balance_itr = balances.require_find(owner.value,
         "The specified account does not have a balance table row");
 
-    vector <asset> quantities = balance_itr->quantities;
-    bool found_token = false;
+    vector<asset> quantities  = balance_itr->quantities;
+    bool          found_token = false;
     for (auto itr = quantities.begin(); itr != quantities.end(); itr++) {
         if (itr->symbol == quantity.symbol) {
             found_token = true;
@@ -1340,7 +1341,7 @@ void atomicassets::internal_decrease_balance(
     check(found_token,
         "The specified account does not have a balance for the symbol specified in the quantity");
 
-    //Updating the balances table
+    // Updating the balances table
     if (quantities.size() > 0) {
         balances.modify(balance_itr, same_payer, [&](auto &_balance) {
             _balance.quantities = quantities;
@@ -1389,10 +1390,10 @@ void atomicassets::check_has_collection_auth(
 
 
 /**
-* The "name" attribute is limited to 64 characters max for both assets and collections
-* This function checks that, if there exists an ATTRIBUTE with name: "name", the value of it
-* must be of length <= 64
-*/
+ * The "name" attribute is limited to 64 characters max for both assets and collections
+ * This function checks that, if there exists an ATTRIBUTE with name: "name", the value of it
+ * must be of length <= 64
+ */
 void atomicassets::check_name_length(
     ATTRIBUTE_MAP data
 ) {
@@ -1405,17 +1406,12 @@ void atomicassets::check_name_length(
     }
 }
 
+atomicassets_public::assets_t atomicassets::get_assets(name acc) { return assets_t(get_self(), acc.value); }
 
-atomicassets::assets_t atomicassets::get_assets(name acc) {
-    return assets_t(get_self(), acc.value);
-}
-
-
-atomicassets::schemas_t atomicassets::get_schemas(name collection_name) {
+atomicassets_public::schemas_t atomicassets::get_schemas(name collection_name) {
     return schemas_t(get_self(), collection_name.value);
 }
 
-
-atomicassets::templates_t atomicassets::get_templates(name collection_name) {
+atomicassets_public::templates_t atomicassets::get_templates(name collection_name) {
     return templates_t(get_self(), collection_name.value);
 }


### PR DESCRIPTION
While working on some contract code for a wax game project I found we were duplicating some of your work by manually copying table struct definitions into out own header.
This PR provides a way to have a common source of truth for the table structure definitions that could be used by the atomic-assets code and 3rd party consumers of the atomic-assets tables.
With this change the 3rd party code would only need to import the public header and would have an up-to-date definition of all the table structures.

_I also run clang formatter locally which has modified the formatting of the code. I can include that in the PR if your would like or I can go through and revert the formatting changes this has introduced,_